### PR TITLE
don't update startDate on hangup

### DIFF
--- a/call.coffee
+++ b/call.coffee
@@ -4,7 +4,7 @@ class Call
     @to = data.to
     @_id = data._id || data.callId
     @direction = data.direction
-    @startDate = new Date()
+    @startDate = data.startDate || new Date()
     @active = true
     @user = this.userId
 

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'sipgate:io',
-  version: '0.0.5',
+  version: '0.0.6',
   // Brief, one-line summary of the package.
   summary: 'use sipgate.io in meteor',
   // URL to the Git repository containing the source code for this package.


### PR DESCRIPTION
Bei einem Hangup wird startDate immer neu gesetzt. So lässt sich keine Anrufdauer aufzeichnen.
Jetzt wird startDate beim Erstellen des Objekts übernommen, falls vorhanden.
